### PR TITLE
hammerheadcaf: display: Change loglevel for failed perf lock

### DIFF
--- a/display/libhwcomposer/hwc_mdpcomp.cpp
+++ b/display/libhwcomposer/hwc_mdpcomp.cpp
@@ -2252,7 +2252,7 @@ void MDPComp::setPerfHint(hwc_context_t *ctx, hwc_display_contents_1_t* list) {
         sPerfLockHandle = sPerfLockAcquire(0 /*handle*/, 0/*duration*/,
                                     &perfHint, sizeof(perfHint)/sizeof(int));
         if(sPerfLockHandle < 0) {
-            ALOGE("Perf Lock Acquire Failed");
+            ALOGD_IF(isDebug(), "%s: Perf Lock Acquire Failed", __FUNCTION__);
         } else {
             perflockFlag = 1;
         }


### PR DESCRIPTION
Perf lock is expected to fail in a number of cases,
where we don't need it. No need to spam the log.

Change-Id: I4d580715a6c6015d17b438522b3a135415ce411c